### PR TITLE
Make cluster certificate authority optional

### DIFF
--- a/src/config/apis.rs
+++ b/src/config/apis.rs
@@ -114,11 +114,15 @@ impl Config {
 }
 
 impl Cluster {
-    pub fn load_certificate_authority(&self) -> Result<Vec<u8>, Error> {
-        utils::data_or_file_with_base64(
-            &self.certificate_authority_data,
-            &self.certificate_authority,
-        )
+    pub fn load_certificate_authority(&self) -> Option<Result<Vec<u8>, Error>> {
+        if self.certificate_authority_data.is_some() || self.certificate_authority.is_some() {
+            Some(utils::data_or_file_with_base64(
+                &self.certificate_authority_data,
+                &self.certificate_authority,
+            ))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/config/kube_config.rs
+++ b/src/config/kube_config.rs
@@ -55,8 +55,8 @@ impl KubeConfigLoader {
             .map_err(Error::from)
     }
 
-    pub fn ca(&self) -> Result<X509, Error> {
-        let ca = &self.cluster.load_certificate_authority()?;
-        X509::from_pem(&ca).map_err(Error::from)
+    pub fn ca(&self) -> Option<Result<X509, Error>> {
+        let ca = self.cluster.load_certificate_authority()?;
+        Some(ca.and_then(|ca| X509::from_pem(&ca).map_err(Error::from)))
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -41,10 +41,10 @@ pub fn load_kube_config() -> Result<Configuration, Error> {
     let loader = KubeConfigLoader::load(kubeconfig)?;
     let mut client_builder = Client::builder();
 
-    let ca = loader.ca()?;
-    let req_ca = Certificate::from_der(&ca.to_der()?)?;
-    client_builder = client_builder.add_root_certificate(req_ca);
-
+    if let Some(ca) = loader.ca() {
+        let req_ca = Certificate::from_der(&ca?.to_der()?)?;
+        client_builder = client_builder.add_root_certificate(req_ca);
+    }
     match loader.p12(" ") {
         Ok(p12) => {
             let req_p12 = Identity::from_pkcs12_der(&p12.to_der()?, " ")?;


### PR DESCRIPTION
If neither of `certificate-authority-data` or `certificate_authority` is set, do
not try to load a root CA for the client.