### PR TITLE
Add credential-plugin authentication support

### DIFF
--- a/src/config/apis.rs
+++ b/src/config/apis.rs
@@ -92,6 +92,8 @@ pub struct AuthInfo {
 
     #[serde(rename = "auth-provider")]
     pub auth_provider: Option<AuthProviderConfig>,
+
+    pub exec: Option<ExecConfig>,
 }
 
 /// AuthProviderConfig stores auth for specified cloud provider.
@@ -99,6 +101,16 @@ pub struct AuthInfo {
 pub struct AuthProviderConfig {
     pub name: String,
     pub config: HashMap<String, String>,
+}
+
+/// ExecConfig stores credential-plugin configuration.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecConfig {
+    #[serde(rename = "apiVersion")]
+    pub api_version: Option<String>,
+    pub args: Option<Vec<String>>,
+    pub command: String,
+    pub env: Option<Vec<HashMap<String, String>>>,
 }
 
 /// NamedContext associates name with context.
@@ -145,7 +157,9 @@ impl AuthInfo {
                 self.token = Some(provider.config["access-token"].clone());
                 if utils::is_expired(&provider.config["expiry"]) {
                     let client = oauth2::CredentialsClient::new()?;
-                    let token = client.request_token(&vec!["https://www.googleapis.com/auth/cloud-platform".to_string()])?;
+                    let token = client.request_token(&vec![
+                        "https://www.googleapis.com/auth/cloud-platform".to_string(),
+                    ])?;
                     self.token = Some(token.access_token);
                 }
             }

--- a/src/config/exec.rs
+++ b/src/config/exec.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+use failure::Error;
+use serde_json;
+
+use config::apis;
+
+/// ExecCredentials is used by exec-based plugins to communicate credentials to
+/// HTTP transports.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecCredential {
+    pub kind: Option<String>,
+    #[serde(rename = "apiVersion")]
+    pub api_version: Option<String>,
+    pub spec: Option<ExecCredentialSpec>,
+    pub status: Option<ExecCredentialStatus>,
+}
+
+/// ExecCredenitalSpec holds request and runtime specific information provided
+/// by transport.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecCredentialSpec {}
+
+/// ExecCredentialStatus holds credentials for the transport to use.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecCredentialStatus {
+    #[serde(rename = "expirationTimestamp")]
+    pub expiration_timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub token: Option<String>,
+    #[serde(rename = "clientCertificateData")]
+    pub client_certificate_data: Option<String>,
+    #[serde(rename = "clientKeyData")]
+    pub client_key_data: Option<String>,
+}
+
+pub fn auth_exec(auth: &apis::ExecConfig) -> Result<ExecCredential, Error> {
+    let mut cmd = Command::new(&auth.command);
+    if let Some(args) = &auth.args {
+        cmd.args(args);
+    }
+    if let Some(env) = &auth.env {
+        let envs = env
+            .iter()
+            .flat_map(|env| match (env.get("name"), env.get("value")) {
+                (Some(name), Some(value)) => Some((name, value)),
+                _ => None,
+            });
+        cmd.envs(envs);
+    }
+    let out = cmd.output()?;
+    if !out.status.success() {
+        return Err(format_err!("command `{:?}` failed: {:?}", cmd, out));
+    }
+    serde_json::from_slice(&out.stdout).map_err(Error::from)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate http;
 extern crate openssl;
 extern crate reqwest;
 extern crate serde;
+extern crate serde_json;
 extern crate serde_yaml;
 extern crate time;
 extern crate url;


### PR DESCRIPTION
This adds support for credential-plugin authentication.

https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

This is used by the Kubernetes AWS IAM authenticator.

https://github.com/kubernetes-sigs/aws-iam-authenticator

I took the data types from here:

https://github.com/kubernetes/client-go/blob/03bfb9bdcfe5482795b999f39ca3ed9ad42ce5bb/pkg/apis/clientauthentication/v1beta1/types.go

There is a timestamp that should probably be converted to a time object. I haven't looked into how the Go client handles refreshing the credentials.