### PR TITLE
async/await, 2018 edition, updated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kubernetes"
 version = "0.1.0"
+edition = "2018"
 description = "Kubernetes rust client"
 authors = ["ynqa <un.pensiero.vano@gmail.com>"]
 license-file = "LICENSE"
@@ -10,21 +11,27 @@ keywords = ["kubernetes"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-base64 = "0.9.3"
+base64 = "0.12.0"
 chrono = "0.4.6"
 dirs = "1.0.4"
 failure = "0.1.2"
-http = "0.1.14"
+http = "0.2"
 lazy_static = "1.3.0"
 openssl = "0.10.12"
-reqwest = "0.9.2"
-serde = "1.0.79"
-serde_derive = "1.0.79"
 serde_json = "1.0.39"
 serde_yaml = "0.8.5"
 time = "0.1.42"
 url = "1.7.2"
 
+[dependencies.serde]
+version = "1"
+features = ["derive"]
+
+[dependencies.reqwest]
+version = "0.10.4"
+features = ["json", "blocking", "native-tls"]
+
 [dev-dependencies]
 tempfile = "3.0.4"
-k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi-codegen", tag = "v0.4.0", features = ["v1_13"] }
+tokio = { version = "0.2", features = ["macros"] }
+k8s-openapi = { git = "https://github.com/Arnavion/k8s-openapi-codegen", tag = "v0.7.0", features = ["v1_15"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-client"]
 
 [dependencies]
 base64 = "0.12.0"
-chrono = "0.4.6"
+chrono = "0.4.11"
 dirs = "1.0.4"
 failure = "0.1.2"
 http = "0.2"
@@ -20,7 +20,6 @@ lazy_static = "1.3.0"
 openssl = "0.10.12"
 serde_json = "1.0.39"
 serde_yaml = "0.8.5"
-time = "0.1.42"
 url = "1.7.2"
 
 [dependencies.serde]

--- a/examples/incluster_config.rs
+++ b/examples/incluster_config.rs
@@ -3,16 +3,19 @@ extern crate k8s_openapi;
 extern crate kubernetes;
 
 use k8s_openapi::api::core::v1 as api;
+use k8s_openapi::List;
 use kubernetes::client::APIClient;
 use kubernetes::config;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let kubeconfig = config::incluster_config().expect("failed to load incluster config");
     let kubeclient = APIClient::new(kubeconfig);
     let (req, _) = api::Pod::list_namespaced_pod("kube-system", Default::default())
         .expect("failed to create a request");
     let list_pod = kubeclient
-        .request::<api::PodList>(req)
+        .request::<List<api::Pod>>(req)
+        .await
         .expect("failed to list up pods");
     println!("{:?}", list_pod);
 }

--- a/examples/list_pod.rs
+++ b/examples/list_pod.rs
@@ -3,16 +3,19 @@ extern crate k8s_openapi;
 extern crate kubernetes;
 
 use k8s_openapi::api::core::v1 as api;
+use k8s_openapi::List;
 use kubernetes::client::APIClient;
 use kubernetes::config;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let kubeconfig = config::load_kube_config().expect("failed to load kubeconfig");
     let kubeclient = APIClient::new(kubeconfig);
     let (req, _) = api::Pod::list_namespaced_pod("kube-system", Default::default())
         .expect("failed to create a request");
     let list_pod = kubeclient
-        .request::<api::PodList>(req)
+        .request::<List<api::Pod>>(req)
+        .await
         .expect("failed to list up pods");
     println!("{:?}", list_pod);
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
+use super::config::Configuration;
 use failure::{format_err, Error};
 use http;
 use serde::de::DeserializeOwned;
-
-use super::config::Configuration;
 
 /// APIClient requires `config::Configuration` includes client to connect with kubernetes cluster.
 pub struct APIClient {
@@ -32,9 +31,13 @@ impl APIClient {
             other => {
                 return Err(Error::from(format_err!("Invalid method: {}", other)));
             }
-        }
-        .body(body);
+        };
 
-        req.send().await?.json().await.map_err(Error::from)
+        req.body(body)
+            .send()
+            .await?
+            .json()
+            .await
+            .map_err(Error::from)
     }
 }

--- a/src/config/apis.rs
+++ b/src/config/apis.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -5,8 +6,8 @@ use std::path::Path;
 use failure::Error;
 use serde_yaml;
 
-use config::utils;
-use oauth2;
+use crate::config::utils;
+use crate::oauth2;
 
 /// Config stores information to connect remote kubernetes cluster.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/config/exec.rs
+++ b/src/config/exec.rs
@@ -1,9 +1,10 @@
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
-use failure::Error;
+use failure::{format_err, Error};
 use serde_json;
 
-use config::apis;
+use crate::config::apis;
 
 /// ExecCredentials is used by exec-based plugins to communicate credentials to
 /// HTTP transports.

--- a/src/config/incluster_config.rs
+++ b/src/config/incluster_config.rs
@@ -3,7 +3,7 @@ use std::env;
 use failure::Error;
 use openssl::x509::X509;
 
-use config::utils;
+use crate::config::utils;
 
 pub const SERVICE_HOSTENV: &str = "KUBERNETES_SERVICE_HOST";
 pub const SERVICE_PORTENV: &str = "KUBERNETES_SERVICE_PORT";

--- a/src/config/kube_config.rs
+++ b/src/config/kube_config.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-use failure::Error;
+use failure::{format_err, Error};
 use openssl::pkcs12::Pkcs12;
 use openssl::pkey::PKey;
 use openssl::x509::X509;
 
-use config::apis::{AuthInfo, Cluster, Config, Context};
+use crate::config::apis::{AuthInfo, Cluster, Config, Context};
 
 /// KubeConfigLoader loads current context, cluster, and authentication information.
 #[derive(Debug)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ mod kube_config;
 mod utils;
 
 use base64;
-use failure::Error;
+use failure::{format_err, Error};
 use reqwest::{header, Certificate, Client, Identity};
 
 use self::kube_config::KubeConfigLoader;

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use base64;
 use chrono::{DateTime, Utc};
 use dirs::home_dir;
-use failure::Error;
+use failure::{format_err, Error};
 
 const KUBECONFIG: &str = "KUBECONFIG";
 
@@ -68,7 +68,7 @@ fn test_kubeconfig_path() {
 #[cfg(test)]
 mod tests {
     extern crate tempfile;
-    use config::utils;
+    use crate::config::utils;
     use std::io::Write;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,3 @@
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate serde_derive;
-
-extern crate base64;
-extern crate chrono;
-extern crate dirs;
-extern crate http;
-extern crate openssl;
-extern crate reqwest;
-extern crate serde;
-extern crate serde_json;
-extern crate serde_yaml;
-extern crate time;
-extern crate url;
-
 pub mod client;
 pub mod config;
 mod oauth2;

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs::File;
 use std::path::PathBuf;
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use failure::{format_err, Error};
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
@@ -11,7 +11,6 @@ use openssl::sign::Signer;
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
-use time::Duration;
 use url::form_urlencoded::Serializer;
 
 const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -3,13 +3,14 @@ use std::fs::File;
 use std::path::PathBuf;
 
 use chrono::Utc;
-use failure::Error;
+use failure::{format_err, Error};
 use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Padding;
 use openssl::sign::Signer;
+use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
-use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use time::Duration;
 use url::form_urlencoded::Serializer;
 


### PR DESCRIPTION
This brings the crate up to date with changes in the ecosystem.

The changes here backwards-incompatible, but allow it to be easily used with recent tokio (std::future based) and k8s-openapi-codegen versions (previously broken by a switch to `http@2.x.x`).

The file system I/O is still done with blocking APIs, as the code looks tricky to migrate. The consumer can schedule that part with spawn_blocking if needed.

Tests and the list_pod example work. I haven't tested the incluster_config example.